### PR TITLE
Change split() function to explode() function

### DIFF
--- a/src/report/html/calendar/index.php
+++ b/src/report/html/calendar/index.php
@@ -32,7 +32,7 @@ $myurl   = 0;
 ## No need to change anything below this line
 
 //Let's grab the proper working directory relative to the url.
-$rel_url = join(array_slice(split( "/" ,dirname($_SERVER['PHP_SELF'])),0,-1),"/");
+$rel_url = join(array_slice(explode( "/" ,dirname($_SERVER['PHP_SELF'])),0,-1),"/");
 
 $prog_dir = getcwd();  // get the current directory
 chdir(".."); //back it up one


### PR DESCRIPTION
As of PHP the split() function was DEPRECATED in PHP 5.3.0, and REMOVED in PHP 7.0.0. 

Calls to split() throws errors in PHP 7.0 and newer.  Replacing it with explode() seems to do the trick.

